### PR TITLE
新增Hook以自動填充wiki collection頁面的category欄位。

### DIFF
--- a/_plugins/categorize_wiki_hook.rb
+++ b/_plugins/categorize_wiki_hook.rb
@@ -1,24 +1,24 @@
-require 'pathname';
+require 'pathname'
 
 # This hook adds subdirectories of the wiki collection as the categories of the
 # current wiki page. This assumes directory structure like _wiki/C1/C2/C3/page.md.
 Jekyll::Hooks.register :wiki, :post_init do |wiki|
-    # Choosing post_init hook because categories are typically populated
-    # during init time(refer to Jekyll Document class code).
-    # This is the soonest possible time to properly populate categories.
+  # Choosing post_init hook because categories are typically populated
+  # during init time(refer to Jekyll Document class code).
+  # This is the soonest possible time to properly populate categories.
 
-    # absolute path to _wiki directory on the system
-    collection_root = Pathname.new(wiki.collection.directory)
-    # absolute path to the currect wiki Markdown file
-    wiki_file_path = Pathname.new(wiki.path)
-    # Directories to be considered as categories.
-    # For example, in case of _wiki/C1/C2/C3/page.md, C1/C2/C3 should be considered.
-    #
-    # In case of _wiki/page.md, this yields ./ and therefore we need to exclude a
-    # category of '.' later; this also means such pages won't have categories.
-    category_dirs = wiki_file_path.relative_path_from(collection_root).dirname
+  # absolute path to _wiki directory on the system
+  collection_root = Pathname.new(wiki.collection.directory)
+  # absolute path to the currect wiki Markdown file
+  wiki_file_path = Pathname.new(wiki.path)
+  # Directories to be considered as categories.
+  # For example, in case of _wiki/C1/C2/C3/page.md, C1/C2/C3 should be considered.
+  #
+  # In case of _wiki/page.md, this yields ./ and therefore we need to exclude a
+  # category of '.' later; this also means such pages won't have categories.
+  category_dirs = wiki_file_path.relative_path_from(collection_root).dirname
 
-    wiki.data['categories'] = category_dirs.to_s
-                              .split(File::SEPARATOR)
-                              .reject do |dir| dir == '.' end
+  wiki.data['categories'] = category_dirs.to_s
+                            .split(File::SEPARATOR)
+                            .reject { |dir| dir == '.' }
 end

--- a/_plugins/categorize_wiki_hook.rb
+++ b/_plugins/categorize_wiki_hook.rb
@@ -1,0 +1,24 @@
+require 'pathname';
+
+# This hook adds subdirectories of the wiki collection as the categories of the
+# current wiki page. This assumes directory structure like _wiki/C1/C2/C3/page.md.
+Jekyll::Hooks.register :wiki, :post_init do |wiki|
+    # Choosing post_init hook because categories are typically populated
+    # during init time(refer to Jekyll Document class code).
+    # This is the soonest possible time to properly populate categories.
+
+    # absolute path to _wiki directory on the system
+    collection_root = Pathname.new(wiki.collection.directory)
+    # absolute path to the currect wiki Markdown file
+    wiki_file_path = Pathname.new(wiki.path)
+    # Directories to be considered as categories.
+    # For example, in case of _wiki/C1/C2/C3/page.md, C1/C2/C3 should be considered.
+    #
+    # In case of _wiki/page.md, this yields ./ and therefore we need to exclude a
+    # category of '.' later; this also means such pages won't have categories.
+    category_dirs = wiki_file_path.relative_path_from(collection_root).dirname
+
+    wiki.data['categories'] = category_dirs.to_s
+                              .split(File::SEPARATOR)
+                              .reject do |dir| dir == '.' end
+end

--- a/search.json
+++ b/search.json
@@ -4,9 +4,10 @@ layout: null
 [
   {% for post in site.wiki %}
     {
-      "title"    : "{{ post.title | escape }}",
-      "tags"     : {{ post.tags | jsonify }},
-      "url"      : "{{ site.baseurl }}{{ post.url }}",
+      "title"      : "{{ post.title | escape }}",
+      "categories" : {{ post.categories | jsonify }},
+      "tags"       : {{ post.tags | jsonify }},
+      "url"        : "{{ site.baseurl }}{{ post.url }}",
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
# Commit訊息

一般Jekyll的category填充法，是從所屬collection資料夾起，一直往父目錄
走至網站根目錄，途中經過的資料夾名稱即為該頁面的category。亦即是說，
以site-root/A/B/C/_wiki/page.md為例，該頁面的categories欄位應自動填為
["A", "B", "C"]。

但由於我們使用的資料夾結構不如一般Jekyll結構；我們是將_wiki資料夾置於
網站根目錄的，如site-root/_wiki/A/B/C/page.md。這樣的結構令Jekyll不會
自動填充page.md的category。

新增的Hook能在一個頁面在Jekyll系統內被創建的時候，以我們的資料夾結構
法則，填充wiki collection內頁面的category欄位。

# 測試

生成後打開search.json，裡面能看見categories一欄有正確出現。