### PR TITLE
簡化tag_index.html中Liquid語法。

### DIFF
--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -2,18 +2,17 @@
 layout: wiki
 ---
 <h1>{{ page.title | escape }}</h1>
-{%- assign sorted_pages = site.wiki | sort: 'url' -%}
-{%- for sorted_page in sorted_pages -%}
-  {%- for tag in sorted_page.tags -%}
-    {%- if tag.name == page.tag -%}
-      <div class="tagsearch__box box">
-        <a href="{{ sorted_page.url }}">
-          {{ sorted_page.title | escape }}
-        </a>
-        <p>
-          {{ sorted_page.excerpt | strip_html }}
-        </p>
-      </div>
-    {%- endif -%}
-  {%- endfor -%}
+{%- assign sorted_docs = site.wiki 
+                         | where_exp: "doc",
+                           "doc.tags contains page.tag"
+                         | sort: "url" -%}
+{%- for sorted_doc in sorted_docs -%}
+  <div class="tagsearch__box box">
+    <a href="{{ sorted_doc.url }}">
+      {{ sorted_doc.title | escape }}
+    </a>
+    <p>
+      {{ sorted_doc.excerpt | strip_html }}
+    </p>
+  </div>
 {%- endfor -%}


### PR DESCRIPTION
使用where_exp首先取得所有符合條件的document，及後再排序。這樣不僅可
以減少需排序的頁面，更可省略巢狀迴圈及條件判斷，使tag_index.html更簡
潔和更易維護。