### PR TITLE
將figure的重置邏輯從在post_init階段執行改為在pre_render階段執行，修正編號沒有每頁重置的問題。

### DIFF
--- a/_plugins/figure.rb
+++ b/_plugins/figure.rb
@@ -7,7 +7,7 @@ module Figure
   end
 
   # resets the numbering information for each page
-  Jekyll::Hooks.register :documents, :post_init do |doc|
+  Jekyll::Hooks.register :documents, :pre_render do |doc|
     # for every new page, we reset the numbering information
     self.numbering = {}
     self.curr_number = 0
@@ -20,7 +20,7 @@ module Figure
   #   some markdown, 
   #   the image would be put here
   #
-  # {% caption "<format string>" %}
+  # {% caption fmt:"<format string>" txtfmt:"<format string>" %}
   #
   #   some caption markdown;
   #   if the whole block is omitted, no caption nor numbering is generated for this figure.


### PR DESCRIPTION
原本編號重置是發生在post_init，因為錯誤假設了每一頁的init都是在上一頁
render完畢之後發生；但實際上，一個頁面init之後並不會立即render，而是
執行下一個頁面的init，所以用post_init重置是沒用的。