### PR TITLE
修正 figure 標籤裡無法使用 markdown 語法。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 3.8.5"
+gem "jekyll", "~> 4.0"
 
 
 # If you have any plugins, put them here!

--- a/_plugins/figure.rb
+++ b/_plugins/figure.rb
@@ -119,7 +119,7 @@ module Figure
           @current_block = @caption = Liquid::BlockBody.new
   
           # change caption format if defined in the markup
-          markup = unquote(markup.strip)
+          markup = unquote markup.strip
           markup.scan(Liquid::TagAttributes) do |key, value|
             case key
             when 'fmt'
@@ -128,13 +128,12 @@ module Figure
               @captext_fmt = unquote value
             end
           end
-  
-          return
         else
           # this is not the first caption in this block,
           # do no more parsing because it is invalid
           @current_block = nil
         end
+        return
       end
   
       # other unknown tags, let the super class handle it
@@ -142,10 +141,6 @@ module Figure
     end
   
     def render(context)
-      # we need this converted to convert markdown to html
-      # or else the final html would just be the original input markdown text
-      converter = context.registers[:site].find_converter_instance(Jekyll::Converters::Markdown) 
-  
       # generate the pieces of figure in markdown
       body    = @body.render(context)
       captext = if @caption.nil? then '' else Liquid::Template.parse(@captext_fmt).render({
@@ -155,13 +150,13 @@ module Figure
         'ref'     => @ref,
         'caption' => captext
       })                                    
-  
-      "<figure id=\"#{@label}\">"                      +
-        remove_paragraph(converter.convert(body))      +
-        '<figcaption>'                                 +
-          remove_paragraph(converter.convert(caption)) +
-        '</figcaption>'                                +
-      '</figure>'
+                                                         "\n" +
+      "<figure markdown=\"1\" id=\"#{@label}\">"       + "\n" +
+        body                                           + "\n" +
+        '<figcaption markdown="1">'                    + "\n" +
+          caption                                      + "\n" +
+        '</figcaption>'                                + "\n" +
+      '</figure>'                                      + "\n"
     end
   
     Liquid::Template.register_tag('figure', self)


### PR DESCRIPTION
這是因為 figure 標籤會將裡面的 markdown 包裹在 <figure></figure> 之中，
而眾多 markdown 的轉換器（包括 Jekyll 內建的 Kramdown），均不會將 HTML
標籤中的 markdown 作轉換。

幸好 Kramdown 是很多 markdown 轉換器的集大成；它支援其他轉換器的自訂語法。
其中它支持的有 PHP Markdown Extra。在 PHP Markdown Extra 中，在包裹
markdown 的 HTML 標籤裡新增 markdown="1" 的屬性，即可促使轉換引擎將該標籤
中的 markdown 轉換。

這個修改將 figure 插件生成的 HTML 標籤中加入 markdown="1" 屬性，使
Kramdown 正確將 figure 裡面的 markdown 轉換。