### PR TITLE
使 embed 插件生成的 YouTube 外嵌使用 https 協定。

### DIFF
--- a/_plugins/embeds.rb
+++ b/_plugins/embeds.rb
@@ -64,7 +64,7 @@ class YouTube < Liquid::Tag
   end
 
   def render(context)
-    "<div class=\"video-container mb3\"><iframe width=\"560\" height=\"400\" frameborder=\"0\" allowfullscreen src=\"http://www.youtube.com/embed/#{@id}?color=white&theme=light&rel=0&amp;showinfo=0\"></iframe></div>"
+    "<div class=\"video-container mb3\"><iframe width=\"560\" height=\"400\" frameborder=\"0\" allowfullscreen src=\"https://www.youtube.com/embed/#{@id}?color=white&theme=light&rel=0&amp;showinfo=0\"></iframe></div>"
   end
 
   Liquid::Template.register_tag "youtube", self


### PR DESCRIPTION
原本是寫用 http，在 https 運行的 puyo.tw 是不能使用的。