### PR TITLE
使 figure 和嵌入式影片水平置中，及 figcaption 字體變小。

### DIFF
--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -237,3 +237,15 @@ body {
     transition: max-height 0.4s cubic-bezier(.83,.43,0,1.02);
   }
 }
+
+div.video-container {
+  text-align: center;
+}
+
+.markdown-section figure {
+  text-align: center;
+
+  > figcaption {
+    font-size: smaller;
+  }
+}


### PR DESCRIPTION
使用 text-align: center 的 css，在目前的 use case，能使 figure 的內容水平置中。目前的 use case 有 iframe、圖片、文字，這些似乎都能使用 text-align 屬性。